### PR TITLE
Pair page not loading bug

### DIFF
--- a/src/pages/pairs/[id].js
+++ b/src/pages/pairs/[id].js
@@ -103,6 +103,12 @@ function PairPage(props) {
   .subtract(1, 'day')
   .unix()
 
+  const utc48HoursAgo = dayjs()
+  .utc()
+  .startOf('hour')
+  .subtract(2, 'day')
+  .unix()
+
   const {
     data: { pair },
   } = useQuery(pairQuery, {
@@ -145,16 +151,12 @@ function PairPage(props) {
     if (date && date >= utc24HoursAgo) {
       volumeToday += volumeForHour
       txCountToday += txCountForHour
-      console.log("today" + i)
-    } else {
+    } else if (date && date >= utc48HoursAgo) {
       volumeYesterday += volumeForHour
       txCountYesterday += txCountForHour
-      console.log("yesterday: " + i)
     }
   }
-  console.log(pair)
-  console.log(volumeToday)
-  console.log(volumeYesterday)
+
   const volumeChange = ((volumeToday - volumeYesterday) / volumeYesterday) * 100;
 
   const fees = volumeToday * FEE_RATE;


### PR DESCRIPTION
Passing in dateAfter to the pairQuery was causing it to fail for some reason, even though the same variable is passed into the pairsQuery. Removing that param fixes the bug. 