### PR TITLE
Fix missing token one day volume 

### DIFF
--- a/src/core/queries/exchange.js
+++ b/src/core/queries/exchange.js
@@ -403,7 +403,7 @@ export const tokensQuery = gql`
 // block @client @export(as: "block")
 export const tokensTimeTravelQuery = gql`
   query tokensTimeTravelQuery($first: Int! = 1000, $block: Block_height!) {
-    tokens(first: $first, block: $block) {
+    tokens(first: $first, block: $block, orderBy: volumeUSD, orderDirection: desc) {
       ...tokenFields
     }
   }


### PR DESCRIPTION
- Adjust tokensTimeTravelQuery to return first 1000 tokens ordered by volumeUSD, same as we do for tokensQuery